### PR TITLE
Reduced number of iterations for sync:barrier_stress test to prevent …

### DIFF
--- a/verifier/sync/osh_sync_tc6.c
+++ b/verifier/sync/osh_sync_tc6.c
@@ -21,7 +21,7 @@
  ***************************************************************************/
 static int test_item1(void);
 
-#define NUMBER_OF_ITERATIONS 100000
+#define NUMBER_OF_ITERATIONS 10000
 
 /****************************************************************************
  * Test Case processing procedure


### PR DESCRIPTION
…time-out issues with automated testing systems.